### PR TITLE
Bot Definition Map Update

### DIFF
--- a/cogs/config/bot_definition_map.json
+++ b/cogs/config/bot_definition_map.json
@@ -104,5 +104,10 @@
 	"def_onyx_bot" : "Onyx",
 	"def_onyx_bot_pr" : "Onyx prototype",
 	"def_spectator_bot" : "Spectator",
-	"def_spectator_bot_pr" : "Spectator prototype"
+	"def_spectator_bot_pr" : "Spectator prototype",
+	"def_gropho_reward1_bot" : "Praetorian Gropho",
+	"def_seth_reward1_bot" : "Mercenary Seth",
+	"def_mesmer_reward1_bot" : "Vanguard Mesmer",
+	"def_terramotus_bot_pr" : "Terramotus prototype",
+	"def_terramotus_bot" : "Terramotus"
 }

--- a/cogs/config/bot_definition_map.json
+++ b/cogs/config/bot_definition_map.json
@@ -108,6 +108,10 @@
 	"def_gropho_reward1_bot" : "Praetorian Gropho",
 	"def_seth_reward1_bot" : "Mercenary Seth",
 	"def_mesmer_reward1_bot" : "Vanguard Mesmer",
+	"def_terramotus_bot" : "Terramotus",
 	"def_terramotus_bot_pr" : "Terramotus prototype",
-	"def_terramotus_bot" : "Terramotus"
+	"def_beholder_bot": "Beholder",
+	"def_beholder_bot_pr": "Beholder prototype",
+	"def_ares_bot": "Ares",
+	"def_ares_bot_pr": "Ares prototype"
 }

--- a/cogs/config/bot_definition_map.json
+++ b/cogs/config/bot_definition_map.json
@@ -102,5 +102,7 @@
 	"def_hydra_bot" : "Hydra",
 	"def_hydra_bot_pr" : "Hydra prototype",
 	"def_onyx_bot" : "Onyx",
-	"def_onyx_bot_pr" : "Onyx prototype"
+	"def_onyx_bot_pr" : "Onyx prototype",
+	"def_spectator_bot" : "Spectator",
+	"def_spectator_bot_pr" : "Spectator prototype"
 }


### PR DESCRIPTION
main script uses bot definition map as a safety measure if API request returns **null** value.
![image](https://github.com/OpenPerpetuum/OPDiscordBot/assets/10224319/aebd388c-3be7-4e41-9e19-203867792f4e)

